### PR TITLE
Catch-up merge for v2.0.0 changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,11 @@ ENV XH_NGINX_CONFIG_INCL_PATH=/etc/nginx/includes
 ENV XH_NGINX_CONTENT_PATH=/usr/share/nginx/html
 
 # Install some useful basic utilities
-RUN apt-get update && apt-get install -y nano vim procps htop dnsutils
+RUN apt-get update && apt-get install -y \
+    dnsutils \
+    procps \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
 
 # Clear out default nginx config and welcome page
 RUN rm $XH_NGINX_CONFIG_PATH/default.conf && rm $XH_NGINX_CONTENT_PATH/*

--- a/includes/xh-hardeners.conf
+++ b/includes/xh-hardeners.conf
@@ -1,2 +1,6 @@
 # Guard against clickjacking
 add_header X-Frame-Options "SAMEORIGIN";
+
+# Set Cookie policy to enforce HTTPS via "Secure", but also allow cross-site access. This supports
+# accepting e.g. JSESSIONID from a remote Hoist app to allow Config Differ  to continue to work.
+proxy_cookie_path / "/; HTTPOnly; Secure; SameSite=None";

--- a/includes/xh-proxy.conf
+++ b/includes/xh-proxy.conf
@@ -7,8 +7,9 @@ proxy_set_header X-Forwarded-Host $host;
 proxy_set_header X-Forwarded-Server $host;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-# Required for NTLM SSO when using Jespa
-proxy_set_header Jespa-Connection-Id $remote_addr:$remote_port;
+# Required for NTLM SSO when using Jespa - should contain client remote_addr:remote_port to uniquely
+# ID client connection across multi-step NTLM handshake. Var is set in xh.conf, see notes there.
+proxy_set_header Jespa-Connection-Id $xh_jespa_connection_id;
 
 # Additional SSL support
 proxy_set_header X-Forwarded-Proto $scheme;

--- a/includes/xh-proxy.conf
+++ b/includes/xh-proxy.conf
@@ -21,6 +21,6 @@ proxy_set_header Upgrade $http_upgrade;
 proxy_set_header Connection "upgrade";
 
 # Longer timeouts to allow long-running calls
-proxy_connect_timeout 120;
-proxy_read_timeout 120;
-proxy_send_timeout 120;
+proxy_connect_timeout 300;
+proxy_read_timeout 300;
+proxy_send_timeout 300;

--- a/xh.conf
+++ b/xh.conf
@@ -6,6 +6,12 @@ gzip_min_length 1000;
 gzip_proxied any;
 gzip_types application/json application/javascript text/css text/javascript;
 
+# Increase client max body size to allow for larger uploads
+client_max_body_size 20m;
+
+# Increase proxy headers hash size due to our use of proxy_set_header - as per nginx msg in log.
+proxy_headers_hash_max_size 1024;
+
 # Convenience map to specify caching expiry by request type (use in expires directive as below)
 map $sent_http_content_type $expires {
     default                 off;
@@ -15,9 +21,6 @@ map $sent_http_content_type $expires {
     text/css                max;
     text/html               epoch;
 }
-
-# Increase client max body size to allow for larger uploads
-client_max_body_size 20m;
 
 # Set $is_desktop and $is_mobile variables for simple UA-based sniffing.
 # This was snagged from https://gist.github.com/perusio/1326701 and is not guaranteed by any means
@@ -34,6 +37,19 @@ map $is_desktop $is_mobile {
     1 0;
     0 1;
 }
+
+# Set new $xh_jespa_connection_id for use in xh-proxy include, where the resulting value is
+# used to add/replace a Jespa-Connection-Id header. If request arrives with a Jespa-Connection-Id
+# header already set, this map will re-use that same value: the incoming header is assumed to
+# have been set by an upstream proxy or k8s ingress and to contain the actual client addr and port.
+# Otherwise, we create the ID with the addr and port we know about here.
+map $http_jespa_connection_id $xh_jespa_connection_id {
+    volatile;
+    default $http_jespa_connection_id;
+
+    ""      $remote_addr:$remote_port;
+}
+
 
 # App-level Dockerfiles must copy in an appropriate conf with server directives such as the below.
 

--- a/xh.conf
+++ b/xh.conf
@@ -22,20 +22,29 @@ map $sent_http_content_type $expires {
     text/html               epoch;
 }
 
-# Set $is_desktop and $is_mobile variables for simple UA-based sniffing.
-# This was snagged from https://gist.github.com/perusio/1326701 and is not guaranteed by any means
-# to be perfect or exhaustive. Apps should use with care - we can tune if we have real-world cases
-# where we find this is not working as desired.
-map $http_user_agent $is_desktop {
-    default 0;
-    ~*linux.*android|windows\s+(?:ce|phone) 0; # exceptions to the rule
-    ~*spider|crawl|slurp|bot 1; # bots
-    ~*windows|linux|os\s+x\s*[\d\._]+|solaris|bsd 1; # OSes
+# Determine the device type via UA sniffing for setting the $is_desktop, $is_mobile, and $is_tablet
+# Snagged from https://gist.github.com/perusio/1326701#gistcomment-2009231 and is not guaranteed
+# by any means to be perfect or exhaustive. Apps should use with care - we can tune if we have
+# real-world cases where we find this is not working as desired.
+map $http_user_agent $ua_device {
+	default 'desktop';
+	~*(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge\ |maemo|midp|mmp|mobile.+firefox|netfront|opera\ m(ob|in)i|palm(\ os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows\ ce|xda|xiino/i 'mobile';
+	~*android|ipad|playbook|silk/i 'tablet';
 }
 
-map $is_desktop $is_mobile {
-    1 0;
-    0 1;
+map $ua_device $is_mobile {
+    default 0;
+    mobile 1;
+}
+
+map $ua_device $is_tablet {
+    default 0;
+    tablet 1;
+}
+
+map $ua_device $is_desktop {
+    default 0;
+    desktop 1;
 }
 
 # Set new $xh_jespa_connection_id for use in xh-proxy include, where the resulting value is


### PR DESCRIPTION
+ These updates have been sitting in `develop` for some time and are actively used across apps via `xh-nginx:next`.
+ Merging to master as v2.0.0.